### PR TITLE
Bump lxml to 4.3.5 to support python 3.8.3

### DIFF
--- a/Formula/visidata.rb
+++ b/Formula/visidata.rb
@@ -64,8 +64,8 @@ class Visidata < Formula
   end
 
   resource "lxml" do
-    url "https://files.pythonhosted.org/packages/da/b5/d3e0d22649c63e92cb0902847da9ae155c1e801178ab5d272308f35f726e/lxml-4.3.4.tar.gz"
-    sha256 "3ce1c49d4b4a7bc75fb12acb3a6247bb7a91fe420542e6d671ba9187d12a12c2"
+    url "https://files.pythonhosted.org/packages/36/14/4e58e16122dd50577a2bfa883c19bd781e223714d55a0d97f56ea506763c/lxml-4.3.5.tar.gz"
+    sha256 "738862e9724d201f1aa8394cb666d8136d666198e97d6e1e5c9876ad884a86b3"
   end
 
   def install


### PR DESCRIPTION
This formula is broken on my machine with the following error:
```
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/include -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers -DCYTHON_CLINE_IN_TRACEBACK=0 -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include -Isrc -Isrc/lxml/includes -I/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/include/python3.8 -c src/lxml/etree.c -o build/temp.macosx-10.15-x86_64-3.8/src/lxml/etree.o -w -flat_namespace
    src/lxml/etree.c:228068:256: error: too many arguments to function call, expected 15, have 16
      __pyx_codeobj__90 = (PyObject*)__Pyx_PyCode_New(2, 0, 2, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__89, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_src_lxml_etree_pyx, __pyx_n_s_getitem, 95, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__90)) __PYX_ERR(0, 95, __pyx_L1_error)
```

Here's some additional debug information:
```
HOMEBREW_VERSION: 2.4.5
ORIGIN: https://github.com/Homebrew/brew
HEAD: 6d2c39579e22d0ee9baccdccdd8a12efb8b00304
Last commit: 15 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 5821fdadc68b16277990fc41baa5290a96897d27
Core tap last commit: 3 hours ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_EDITOR: code-insiders
HOMEBREW_MAKE_JOBS: 8
CPU: octa-core 64-bit haswell
Homebrew Ruby: 2.6.3 => /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3_2/bin/ruby
Clang: 11.0 build 1103
Git: 2.27.0 => /usr/local/bin/git
Curl: 7.64.1 => /usr/bin/curl
Java: 11.0.7, 1.8.0_242-zulu-8.44.0.9, 1.8.0_144, 1.8.0_121, 1.7.0_262, 1.7.0_80
macOS: 10.15.5-x86_64
CLT: 11.5.0.0.1.1588476445
Xcode: 11.5

HOMEBREW_CC: clang
HOMEBREW_CXX: clang++
MAKEFLAGS: -j8
CMAKE_PREFIX_PATH: /usr/local/opt/openssl@1.1:/usr/local/opt/readline:/usr/local/opt/sqlite:/usr/local
CMAKE_INCLUDE_PATH: /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers
CMAKE_LIBRARY_PATH: /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries
CMAKE_FRAMEWORK_PATH: /usr/local/opt/python@3.8/Frameworks
PKG_CONFIG_PATH: /usr/local/opt/openssl@1.1/lib/pkgconfig:/usr/local/opt/readline/lib/pkgconfig:/usr/local/opt/sqlite/lib/pkgconfig:/usr/local/opt/xz/lib/pkgconfig:/usr/local/opt/python@3.8/lib/pkgconfig
PKG_CONFIG_LIBDIR: /usr/lib/pkgconfig:/usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig/10.15
HOMEBREW_GIT: git
HOMEBREW_SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
ACLOCAL_PATH: /usr/local/share/aclocal
PATH: /usr/local/Homebrew/Library/Homebrew/shims/mac/super:/usr/local/opt/gdbm/bin:/usr/local/opt/openssl@1.1/bin:/usr/local/opt/sqlite/bin:/usr/local/opt/xz/bin:/usr/local/opt/python@3.8/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

I did a little bit of digging, and it seems to go back to an issue with Cython 0.29.10, which lxml 4.3.4 is built using. [Cython was bumped to 0.29.13 in lxml 4.3.5](https://lxml.de/4.4/changes-4.4.0.html), and this fixes the issue on my machine at least.